### PR TITLE
Fix Typo IntellyJ -> IntelliJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Intro
 Far.vim makes it easier to find and replace text through multiple files.
-It's inspired by fancy IDEs, like IntellyJ and Eclipse, that provide
+It's inspired by fancy IDEs, like IntelliJ and Eclipse, that provide
 cozy tools for such tasks.
 
 ## Usage


### PR DESCRIPTION
Change ”IntellyJ“ in the readme to “IntelliJ”