### PR TITLE
Fix bug: error string cutting and syntax highlight for wide characters

### DIFF
--- a/autoload/far.vim
+++ b/autoload/far.vim
@@ -1137,7 +1137,6 @@ function! s:build_buffer_content(far_ctx, win_params) abort "{{{
                 let line_num += 1
                 let line_num_text = '  '.item_ctx.lnum
                 let line_num_col_text = line_num_text.repeat(' ', 8-strchars(line_num_text))
-                " match_val: 匹配到的子串
                 let match_val = matchstr(item_ctx.text, '\v'.a:far_ctx.pattern, item_ctx.cnum-1)
                 let multiline = match(a:far_ctx.pattern, '\\n') >= 0
                 if multiline
@@ -1146,12 +1145,10 @@ function! s:build_buffer_content(far_ctx, win_params) abort "{{{
                 endif
 
                 if a:win_params.result_preview && !multiline && !item_ctx.replaced
-                    " 显示宽度: 此处要 strchars 改成 strdisplaywidth
+                    " strdisplaywidth: actual displayed width, so as to deal with wide characters
                     let max_text_len = a:win_params.width / 2 - strdisplaywidth(line_num_col_text)
                     let max_repl_len = a:win_params.width / 2 - strdisplaywidth(g:far#repl_devider)
-                    " \v: very magic 匹配模式, `:h \v` 以获得帮助
-                    " repl_val: 匹配到的子串 替换得到的子符串
-                    " 第 item_ctx.cnum 个字节(从1开始算) 是匹配到的子串
+                    " item_ctx.cnum : byte id (begin with 1) the matched substring start from
                     let repl_val = substitute(match_val, '\v'.a:far_ctx.pattern, a:far_ctx.replace_with, "")
                     let repl_text = (item_ctx.cnum == 1? '' : item_ctx.text[0:item_ctx.cnum-2]).
                         \   repl_val. item_ctx.text[item_ctx.cnum+len(match_val)-1:]  " change to len, to support replacing wide char
@@ -1183,12 +1180,9 @@ function! s:build_buffer_content(far_ctx, win_params) abort "{{{
                     else
                         if a:win_params.result_preview && !multiline && !item_ctx.replaced
                             let match_col = match_text.val_col
-                            " 被替代子串结尾 到 替代后字符串显示部分结尾 之间的字符个数: 过长, 应该是repl_text.val_col出错
                             let repl_col_h = strchars(repl_text.text) - repl_text.val_col - strchars(repl_val) + 1
-                            " 被替代子串开头 到 替代后字符串显示部分结尾 之间的字节个数: 正确
                             let repl_col_e = len(repl_text.text) - repl_text.val_idx + 1
-                            " 这里 strchars 要改成 strdisplaywidth
-                            " 要搞清楚, rs=s+ 等等 是什么意思
+
                             let line_syn = 'syn region FarItem matchgroup=FarSearchVal '.
                                         \   'start="\%'.line_num.'l\%'.strchars(line_num_col_text).'c"rs=s+'.
                                         \   (match_col+strchars(match_val)).

--- a/autoload/far.vim
+++ b/autoload/far.vim
@@ -1183,13 +1183,7 @@ function! s:build_buffer_content(far_ctx, win_params) abort "{{{
                     else
                         if a:win_params.result_preview && !multiline && !item_ctx.replaced
                             let match_col = match_text.val_col
-                            " let match_idx = match_text.val_idx
-
-                            " let repl_col_h = strchars(repl_text.text) - repl_text.val_col - strchars(repl_val) + 1
-                            " let repl_col_e = strchars(repl_text.text) - repl_text.val_col + 1
-
                             " 被替代子串结尾 到 替代后字符串显示部分结尾 之间的字符个数: 过长, 应该是repl_text.val_col出错
-                            let repl_col_h = 30
                             let repl_col_h = strchars(repl_text.text) - repl_text.val_col - strchars(repl_val) + 1
                             " 被替代子串开头 到 替代后字符串显示部分结尾 之间的字节个数: 正确
                             let repl_col_e = len(repl_text.text) - repl_text.val_idx + 1
@@ -1203,8 +1197,6 @@ function! s:build_buffer_content(far_ctx, win_params) abort "{{{
                             call add(syntaxs, line_syn)
                         else
                             let match_col = match_text.val_col
-                            " let match_idx = match_text.val_idx
-
                             let line_syn = 'syn region FarItem matchgroup=FarSearchVal '.
                                         \   'start="\%'.line_num.'l\%'.strchars(line_num_col_text).'c"rs=s+'.
                                         \   (match_col+strchars(match_val)).
@@ -1277,6 +1269,9 @@ function! s:update_far_buffer(far_ctx, bufnr) abort "{{{
     exec 'norm! Gdd'
     call winrestview(pos)
     setlocal nomodifiable
+
+    " in case someone has set that a new buf starts in insert mode
+    stopinsert
 
     syntax clear
     set syntax=far

--- a/autoload/far.vim
+++ b/autoload/far.vim
@@ -1369,10 +1369,10 @@ function! s:param_proc(far_params, win_params, cmdargs) "{{{
         let a:far_params.range = [-1, -1]
         call far#tools#log('*pattern:'.a:far_params.pattern)
     else
-        let a:far_params.pattern = substitute(a:far_params.pattern, '', '\\n', 'g')
+        let a:far_params.pattern = substitute(a:far_params.pattern, "\<Char-0x0D>", '\\n', 'g')
     endif
 
-    let a:far_params.replace_with = substitute(a:far_params.replace_with, '', '\\r', 'g')
+    let a:far_params.replace_with = substitute(a:far_params.replace_with,  "\<Char-0x0D>", '\\r', 'g')
 
     if a:far_params.file_mask == '%'
         let a:far_params.file_mask = bufname('%')

--- a/autoload/far/tools.vim
+++ b/autoload/far/tools.vim
@@ -108,41 +108,43 @@ function! far#tools#splitcmd(cmdline) "{{{
 endfunction "}}}
 
 function! far#tools#centrify_text(text, width, val_col) abort "{{{
-    " a:text : 完整的字符串, 可以是原串, 可以是替换后的串
-    " a:width: 显示限宽
-    " a:val_col = 从1开始算, 匹配到的子串开始的字节
-    " 修改api, 需要得到 a:val_end_col ?
+    " a:text: text to cut
+    " a:width: the width of displayed text
+    " a:val_col: byte id (begin with 1) the matched substring start from
 
     let text = copy(a:text)
+    " pretext: text before the matched substring
     let pretext = a:val_col == 1 ? '' : text[0: a:val_col - 2]
-    let val_col = strchars(pretext) + 1 " 匹配子串从第几字符开始(从1开始算)
-    let val_idx = a:val_col " 匹配子串从第几字节开始(从1开始算)
+    " val_col: char id (begin with 1) the matched substring start from
+    let val_col = strchars(pretext) + 1
+    " val_idx: byte id (begin with 1) the matched substring start from
+    let val_idx = a:val_col
 
-    let val_show_col = strdisplaywidth(pretext) " = 从1开始算, 匹配到的子串的显示列数-1
-
-    if strdisplaywidth(text) > a:width && val_show_col > a:width/2 - 7
-
+    if strdisplaywidth(text) > a:width && strdisplaywidth(pretext) > a:width/2 - 7
+        " left_start_col: char id (begin with 1) the displayed substring start from
         let left_start_col = val_col
-        let left_show_col = 0
-        while left_show_col < a:width/2 - 7
+        " cut_text_to_val: the displayed text cut on the left, until the matched substring
+        let cut_text_to_val = g:far#cut_text_sign. strcharpart(text, left_start_col - 1, val_col - left_start_col)
+        while strdisplaywidth(cut_text_to_val) < a:width/2 - 7
             let left_start_col -= 1
-            let left_text = strcharpart(text, left_start_col - 1, val_col - left_start_col)
-            let left_show_col = strdisplaywidth(left_text)
+            let cut_text_to_val = g:far#cut_text_sign. strcharpart(text, left_start_col - 1, val_col - left_start_col)
         endwhile
-
+        " text_beyond_left: the left-side undisplayed text
         let text_beyond_left = left_start_col == 1 ? '' : strcharpart(text, 0, left_start_col - 2)
+        " left_start_idx: byte id (begin with 1) the displayed substring start from
         let left_start_idx = len(text_beyond_left) + 1
 
-        " 前阶段字符是地接个字节/字符
-
-        " 字符个数
+        " val_col: the matched substring start from the val_col'th char (begin with 1)
         let val_col = val_col - left_start_col + 2 + strchars(g:far#cut_text_sign)
-        " 字节个数
+        " val_idx: the matched substring start from the val_idx'th byte (begin with 1)
         let val_idx = val_idx - left_start_idx + 1 + len(g:far#cut_text_sign)
+        " text: the displayed text cut on the left
         let text = g:far#cut_text_sign. text[left_start_idx-1:]
     endif
     if strdisplaywidth(text) > a:width
+        " char_num: the number of chars in the displayed text
         let char_num = strchars(text)
+        " text_cut: the displayed text cut on the right
         let text_cut = strcharpart(text,0,char_num).g:far#cut_text_sign
         while strdisplaywidth(text_cut)  > a:width
             let char_num -= 1
@@ -154,6 +156,9 @@ function! far#tools#centrify_text(text, width, val_col) abort "{{{
         let text = text.repeat(' ', a:width - strdisplaywidth(text))
     endif
 
+    " text: cut text
+    " val_col: char id (begin with 1) the matched substring start from
+    " val_idx: byte id (begin with 1) the matched substring start from
     return {'text': text, 'val_col': val_col, 'val_idx': val_idx}
 endfunction "}}}
 


### PR DESCRIPTION
Fix bug: error string cutting and syntax highlight for wide characters

examples with the bug:

![example](https://user-images.githubusercontent.com/30200581/73205094-3db0c800-417b-11ea-87f7-0182edf85de5.png)

fixed example:

![ScreenShot 2020-01-28 03 08 39](https://user-images.githubusercontent.com/30200581/73205193-7ea8dc80-417b-11ea-9ede-05fbabe6ac85.png)

Besides, two small improvement are also committed:
 
* enforce normal mode when starting a new far.vim buffer, in case the customer sets that new buffers start in insert mode.

* replace the `^M` in the source code with `"\<Char-0x0D>"` in case some editors that automatically convert `^M` to `\n` on saving.

