### PR TITLE
Match both files and dirs when a pattern doesn't start and end with `/`

### DIFF
--- a/doc/far.txt
+++ b/doc/far.txt
@@ -397,10 +397,10 @@ FILE MASK                                                      *far-file-mask*
     heading
 
         '/xx'
-            'xx' is directly udner the 'root' dir
+            'xx' is directly under the 'root' dir
 
         'xx'
-            'xx' is recursively udner the 'root' dir
+            'xx' is recursively under the 'root' dir
 
     tailing
 
@@ -447,6 +447,9 @@ FILE MASK                                                      *far-file-mask*
         '/xx/*test*/'
             All dirs with 'test' in name, directly under '<cwd>/xx/' dir.
             Including '/xx/test/' '/xx/test2/' '/xx/1test2/' '/xx/test/'
+
+        'foo'
+            All files named 'foo', and all files under dirs named 'foo'.
 
     only for ignore_rules:
         'zz'
@@ -511,7 +514,9 @@ CONFIGURATION                                                     *far-config*
     Default: 400
 
 *g:far#ignore_files*
-    A list. Files of rules to ignore file during matching. See |far-glob|
+    A list. Files of rules to ignore file during matching.
+    Paths can be absolute or relative to the current working directory.
+    See |far-glob|, |g:far#cwd|
 
     Default: [ '<path-to-far.vim-repo>/farignore' ]
 

--- a/rplugin/python3/far/sources/far_glob.py
+++ b/rplugin/python3/far/sources/far_glob.py
@@ -16,7 +16,7 @@ def proc(rules_origin):
 
     head
     under root: /xx    -> xx
-    anywhere:   xx     -> **/xx
+    anywhere:   xx     -> **/xx, **/xx/**/*
     '''
     rules = []
     for rule_origin in rules_origin:
@@ -32,7 +32,9 @@ def proc(rules_origin):
         if rule[0] == '/':
             rule = rule[1:]
         else:
+            # Match both, files and directories.
             rule = '**/' + rule
+            rules.append(rule + '/**/*')
 
         if rule != '':
             rules.append(rule)


### PR DESCRIPTION
This is related to https://github.com/brooth/far.vim/issues/82#issuecomment-585222809

Currently, to ignore a directory you need to add `foo/` (which is correct!).
But, if you have `foo` (no slashes), it would only ignore files named `foo`, instead of ignoring both files and directories named `foo`.

This behavior is compatible with Git

> If there is a separator at the end of the pattern then the pattern will only match directories, otherwise the pattern can match both files and directories.

https://git-scm.com/docs/gitignore#_pattern_format

Didn't find any way to run the tests, but I have tested this solution with a project.