### PR TITLE
set minimum win content width to 10 (I think 60 is too big)

### DIFF
--- a/autoload/far.vim
+++ b/autoload/far.vim
@@ -11,7 +11,7 @@ call far#tools#setdefault('g:far#repl_devider', ' ➝  ')
 call far#tools#setdefault('g:far#cut_text_sign', '…')
 call far#tools#setdefault('g:far#collapse_sign', '- ')
 call far#tools#setdefault('g:far#expand_sign', '+ ')
-call far#tools#setdefault('g:far#window_min_content_width', 60)
+call far#tools#setdefault('g:far#window_min_content_width', 10)
 call far#tools#setdefault('g:far#preview_window_scroll_step', 1)
 call far#tools#setdefault('g:far#check_window_resize_period', 2000)
 call far#tools#setdefault('g:far#file_mask_favorites',


### PR DESCRIPTION
I was trying to set the window width to 30 but I kept getting an error with `b:win_params`

This will allow a user to specify a win size as low as 10. 