### PR TITLE
Add Ripgrep support for super-speed globbing

### DIFF
--- a/rplugin/python3/far/sources/far_glob.py
+++ b/rplugin/python3/far/sources/far_glob.py
@@ -130,12 +130,8 @@ def far_glob(root, rules, ignore_rules):
     return files
 
 def rg_ignore_globs(files):
-    ignored = []
-    for file in files:
-        ignored.extend(open(file, 'r').read().split('\n'))
-
-    filtered_ignored = [dir.strip() for dir in ignored if len(dir.strip()) > 0 and ("#" not in dir)]
-    return ' '.join(map(lambda dir: f"-g '!{dir}'", filtered_ignored))
+    ignored = {val for sublist in [open(file, 'r').read().split('\n') for file in files] if len(val.strip()) > 0 and ("#" not in val) for val in sublist}
+    return ' '.join(map(lambda dir: f"-g '!{dir}'", ignored))
 
 def rg_rules_glob(rules):
     return ' '.join(map(lambda dir: f"-g '{dir}'", rules))

--- a/rplugin/python3/far/sources/far_glob.py
+++ b/rplugin/python3/far/sources/far_glob.py
@@ -128,3 +128,14 @@ def far_glob(root, rules, ignore_rules):
     ]
 
     return files
+
+def rg_ignore_globs(files):
+    ignored = []
+    for file in files:
+        ignored.extend(open(file, 'r').read().split('\n'))
+
+    filtered_ignored = [dir.strip() for dir in ignored if len(dir.strip()) > 0 and ("#" not in dir)]
+    return ' '.join(map(lambda dir: f"-g '!{dir}'", filtered_ignored))
+
+def rg_rules_glob(rules):
+    return ' '.join(map(lambda dir: f"-g '{dir}'", rules))

--- a/rplugin/python3/far/sources/far_glob.py
+++ b/rplugin/python3/far/sources/far_glob.py
@@ -130,7 +130,7 @@ def far_glob(root, rules, ignore_rules):
     return files
 
 def rg_ignore_globs(files):
-    ignored = {val for sublist in [open(file, 'r').read().split('\n') for file in files] if len(val.strip()) > 0 and ("#" not in val) for val in sublist}
+    ignored = {val for sublist in [open(file, 'r').read().split('\n') for file in files] for val in sublist if len(val.strip()) > 0 and ("#" not in val)}
     return ' '.join(map(lambda dir: f"-g '!{dir}'", ignored))
 
 def rg_rules_glob(rules):

--- a/rplugin/python3/far/sources/shell.py
+++ b/rplugin/python3/far/sources/shell.py
@@ -7,7 +7,7 @@ License: MIT
 
 from pprint import pprint
 
-from .far_glob import load_ignore_rules,far_glob,GlobError,IgnoreFileError
+from .far_glob import load_ignore_rules,far_glob,GlobError,IgnoreFileError,rg_rules_glob,rg_ignore_globs
 import logging
 import subprocess
 import re
@@ -18,13 +18,6 @@ import json
 from json import JSONDecodeError
 
 logger = logging.getLogger('far')
-
-def rg_ignore_globs():
-    ignored = open('/home/ubuntu/.config/nvim/plugged/far.vim/farignore', 'r').read().split('\n')
-    return ' '.join(map(lambda dir: f"-g '!{dir}'" if len(dir) > 0 else "", ignored))
-
-def rg_rules_glob(rules):
-    return ' '.join(map(lambda dir: f"-g '{dir}'", rules))
 
 def search(ctx, args, cmdargs):
     logger.debug('search(%s, %s, %s)', str(ctx), str(args), str(cmdargs))

--- a/rplugin/python3/far/sources/shell.py
+++ b/rplugin/python3/far/sources/shell.py
@@ -42,14 +42,13 @@ def search(ctx, args, cmdargs):
 
     rules = file_mask.split(',')
 
-    ignore_rules = []
-
     if source == 'rg' or source == 'rgnvim' :
         logger.debug(f'Globbing with ripgrep: rg --files {rg_rules_glob(rules)} {rg_ignore_globs(ignore_files)}')
         with tempfile.NamedTemporaryFile(mode='w', delete=False, encoding='utf-8') as fp:
             fp.write(os.popen(f'rg --files {rg_rules_glob(rules)} {rg_ignore_globs(ignore_files)}').read())
 
     else:
+        ignore_rules = []
         for ignore_file in ignore_files:
             try:
                 ignore_rules.extend(

--- a/rplugin/python3/far/sources/shell.py
+++ b/rplugin/python3/far/sources/shell.py
@@ -45,9 +45,9 @@ def search(ctx, args, cmdargs):
     ignore_rules = []
 
     if source == 'rg' or source == 'rgnvim' :
-        logger.debug(f'Globbing with ripgrep: rg --files {rg_rules_glob(rules)} {rg_ignore_globs()}')
+        logger.debug(f'Globbing with ripgrep: rg --files {rg_rules_glob(rules)} {rg_ignore_globs(ignore_files)}')
         with tempfile.NamedTemporaryFile(mode='w', delete=False, encoding='utf-8') as fp:
-            fp.write(os.popen(f'rg --files {rg_rules_glob(rules)} {rg_ignore_globs()}').read())
+            fp.write(os.popen(f'rg --files {rg_rules_glob(rules)} {rg_ignore_globs(ignore_files)}').read())
 
     else:
         for ignore_file in ignore_files:


### PR DESCRIPTION
After trying to use far.vim in a rails project, I encountered search times of up to three minutes. I tracked down the issue to `/rplugin/python3/far/sources/far_glob.py:66`. By iterating over every file in python, there is a massive slowdown. My approach was to replace this altogether, when the source is set to `rg` or `rgnvim`. I use rg to glob the directories, with respect to the content in `farignore` and the supplied file_mask.

There is still a bit to do - but I wanted to see if this is an approach you are at all interested in.

Addresses issue #94 