### PR TITLE
Add glob_mode option and fix a few problems

### DIFF
--- a/autoload/far.vim
+++ b/autoload/far.vim
@@ -27,6 +27,7 @@ call far#tools#setdefault('g:far#case_sensitive', -1)
 call far#tools#setdefault('g:far#word_boundary', 0)
 call far#tools#setdefault('g:far#limit', 1000)
 call far#tools#setdefault('g:far#max_columns', 400)
+call far#tools#setdefault('g:far#glob_mode', 'far')
 
 
 call far#tools#setdefault('g:far#executors', {})
@@ -63,6 +64,7 @@ if executable('ag')
     call far#tools#setdefault('g:far#sources.ag.args.expand_cmdargs', 1)
     call far#tools#setdefault('g:far#sources.ag.args.ignore_files', g:far#ignore_files)
     call far#tools#setdefault('g:far#sources.ag.args.max_columns', g:far#max_columns)
+    call far#tools#setdefault('g:far#sources.ag.args.glob_mode', g:far#glob_mode)
 
     if has('nvim')
         call far#tools#setdefault('g:far#sources.agnvim', {})
@@ -76,6 +78,7 @@ if executable('ag')
         call far#tools#setdefault('g:far#sources.agnvim.args.expand_cmdargs', 1)
         call far#tools#setdefault('g:far#sources.agnvim.args.ignore_files', g:far#ignore_files)
         call far#tools#setdefault('g:far#sources.agnvim.args.max_columns', g:far#max_columns)
+        call far#tools#setdefault('g:far#sources.agnvim.args.glob_mode', g:far#glob_mode)
     endif
 endif
 
@@ -94,6 +97,7 @@ if executable('ack')
     call far#tools#setdefault('g:far#sources.ack.args.expand_cmdargs', 1)
     call far#tools#setdefault('g:far#sources.ack.args.ignore_files', g:far#ignore_files)
     call far#tools#setdefault('g:far#sources.ack.args.max_columns', g:far#max_columns)
+    call far#tools#setdefault('g:far#sources.ack.args.glob_mode', g:far#glob_mode)
 
     if has('nvim')
         call far#tools#setdefault('g:far#sources.acknvim', {})
@@ -107,11 +111,12 @@ if executable('ack')
         call far#tools#setdefault('g:far#sources.acknvim.args.expand_cmdargs', 1)
         call far#tools#setdefault('g:far#sources.acknvim.args.ignore_files', g:far#ignore_files)
         call far#tools#setdefault('g:far#sources.acknvim.args.max_columns', g:far#max_columns)
+        call far#tools#setdefault('g:far#sources.acknvim.args.glob_mode', g:far#glob_mode)
     endif
 endif
 
 if executable('rg')
-    let cmd = ['xargs',  'rg','--json','--with-filename', '--no-heading',
+    let cmd = ['rg', '--json', '--with-filename', '--no-heading',
     \ '--vimgrep',  '--max-count={limit}', '{pattern}',  '{file_mask}']
 
     call far#tools#setdefault('g:far#sources.rg', {})
@@ -125,6 +130,7 @@ if executable('rg')
     call far#tools#setdefault('g:far#sources.rg.args.expand_cmdargs', 1)
     call far#tools#setdefault('g:far#sources.rg.args.ignore_files', g:far#ignore_files)
     call far#tools#setdefault('g:far#sources.rg.args.max_columns', g:far#max_columns)
+    call far#tools#setdefault('g:far#sources.rg.args.glob_mode', g:far#glob_mode)
 
     if has('nvim')
         call far#tools#setdefault('g:far#sources.rgnvim', {})
@@ -138,6 +144,7 @@ if executable('rg')
         call far#tools#setdefault('g:far#sources.rgnvim.args.expand_cmdargs', 1)
         call far#tools#setdefault('g:far#sources.rgnvim.args.ignore_files', g:far#ignore_files)
         call far#tools#setdefault('g:far#sources.rgnvim.args.max_columns', g:far#max_columns)
+        call far#tools#setdefault('g:far#sources.rgnvim.args.glob_mode', g:far#glob_mode)
     endif
 endif
 
@@ -211,6 +218,7 @@ let s:far_params_meta = {
     \   '--case-sensitive' : {'param': 'case_sensitive', 'values': [1,0,-1]},
     \   '--word-boundary' : {'param': 'word_boundary', 'values': [1,0]},
     \   '--max-columns' : { 'param': 'max_columns', 'values': [300,400,'..']},
+    \   '--glob-mode' : {'param': 'glob_mode', 'values': ['far', 'native', 'rg']},
     \   }
 
 let s:far_params_meta_vimgrep = {

--- a/doc/far.txt
+++ b/doc/far.txt
@@ -526,6 +526,27 @@ CONFIGURATION                                                     *far-config*
 
     Default: |getpwd()| value.
 
+*g:far#glob_mode*
+    When using a source other than 'vimgrep', specifies how file globbing
+    should be preformed.  It can take these values:
+
+        'far'
+            Use far.vim's built-in globbing mechanism to retrieve the list of
+            files to search.  Has no external dependencies.  This is the
+            default.
+
+        'native'
+            Use the search source tool's own globbing mechanism.  Currently,
+            for sources other than 'rg'/'rgnvim' (which contains a
+            globbing mechanism), this means that a file or directory is
+            specified as the glob.
+
+        'rg'
+            This uses ripgrep's globbing mechanism, and requires ripgrep to be
+            installed.  It can be used with any external search source.  When
+            using with the 'rg' or 'rgnvim' source, it's equivalent and faster
+            to use 'native' instead.
+
 *g:far#default_mappings*
     Apply default mappings to each FAR buffer. See |far-mappings|.
 

--- a/rplugin/python3/far/sources/far_glob.py
+++ b/rplugin/python3/far/sources/far_glob.py
@@ -130,7 +130,7 @@ def far_glob(root, rules, ignore_rules):
 
     return files
 
-def rg_ignore_globs(files):
+def rg_ignore_globs(files, as_str=True):
     ignored = {
         ignore_glob
         for sublist in [
@@ -141,7 +141,17 @@ def rg_ignore_globs(files):
         for ignore_glob in sublist
         if len(ignore_glob.strip()) > 0 and ("#" not in ignore_glob)
     }
-    return ' '.join(map(lambda dir: f"-g '!{dir}'", ignored))
+    if as_str:
+        return ' '.join(map(lambda dir: f"-g '!{dir}'", ignored))
+    else:
+        return [ '-g' if g else '!' + d for d in ignored for g in (True, False) ]
 
-def rg_rules_glob(rules):
-    return ' '.join(map(lambda dir: f"-g '{dir}'", rules))
+def rg_rules_glob(rules, as_str=True):
+    # Don't include * globbing rules.  rg behaves like this by default, and explicitly
+    # adding these causes rg to stop ignoring its built-in ignored files.
+    rules = [ r for r in rules if r not in ( '*', '**/*' ) ]
+    if as_str:
+        return ' '.join(map(lambda dir: f"-g '{dir}'", rules))
+    else:
+        return [ '-g' if g else d for d in rules for g in (True, False) ]
+


### PR DESCRIPTION
This pull request adds more flexibility to globbing when using external sources, as well as fixing a few globbing-related bugs and a bit of refactoring.  It adds an option `glob_mode` which can be set to `far` (the default, to use far's existing built-in globbing), `native` (uses the source's built-in globbing mechanism, if present - otherwise pass the file mask directly to the tool), or `rg` (to use ripgrep's globbing, can be combined with any source).

Additionally, the following related changes are included:

- It doesn't appear that globbing has been working properly for current versions of ag, since ag does not accept a list of files to search on stdin.  It appears to have just be consistently searching cwd.  This has been fixed.
- When using ripgrep globbing, it was still including `.gitignore` and other files typically ignored by ripgrep.  This has been fixed.
- The use of a temporary file and `cat` to pipe glob results into the search command has been replaced by a direct pipe from python; this should speed it up a bit and is cleaner.
- When using `native` globbing, the separate globbing step is not performed (eliminating a command execution and a bunch of piping) in lieu of passing the globs directly to the search command.

