### PR TITLE
Add optional shell-style cmdline parsing

### DIFF
--- a/autoload/far.vim
+++ b/autoload/far.vim
@@ -27,6 +27,7 @@ call far#tools#setdefault('g:far#case_sensitive', -1)
 call far#tools#setdefault('g:far#word_boundary', 0)
 call far#tools#setdefault('g:far#limit', 1000)
 call far#tools#setdefault('g:far#max_columns', 400)
+call far#tools#setdefault('g:far#cmdparse_mode', g:far#source == 'vimgrep' ? 'vim' : 'shell')
 
 
 call far#tools#setdefault('g:far#executors', {})

--- a/doc/far.txt
+++ b/doc/far.txt
@@ -696,6 +696,13 @@ CONFIGURATION                                                     *far-config*
 
     Default: 1
 
+*g:far#cmdparse_mode*
+    This variable controls how arguments to :F... commands are parsed.  If set
+    to 'vim', uses a style of escaping best suited to vim patterns.  If
+    set to 'shell', it uses bash-style escaping and quoting semantics to parse
+    arguments.  The default is to use 'vim' for the 'vimgrep' source and
+    to use 'shell' for other sources.
+
 ------------------------------------------------------------------------------
 Highlighting Groups:                                    *far-highlight-config*
 

--- a/plugin/far.vim
+++ b/plugin/far.vim
@@ -26,6 +26,7 @@ function! Find(rngmode, rngline1, rngline2, cmdline, ...) range abort "{{{
     call far#tools#log('cmdline: '.a:cmdline)
 
     let cargs = far#tools#splitcmd(a:cmdline)
+    call far#tools#log('cmdline parsed: ' . string(cargs))
     if len(cargs) == 1
         call add(cargs, g:far#default_file_mask)
     endif


### PR DESCRIPTION
This pull request adds a new optional command line parser for the Far vim commands.  The default parser works well for vim-style patterns, but is less convenient when dealing with conventionally shell-based search tools.  The new parser is based on bash's command-line parsing semantics including both kinds of quoting and escaping.

The new parser can be switched in by an option.  I've included the new parser as the default for the shell-based search sources, and am using the old parser as the default for vimgrep.
